### PR TITLE
chore: rework embed loading for videos & spotify

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -35,56 +35,6 @@ function decorateTwitterFeed() {
   });
 }
 
-function createIframe(div) {
-  const a = div.previousElementSibling;
-  const vendor = div.classList[1];
-  const embed = a.pathname;
-  const id = embed.split('/').pop();
-  let source;
-  let className;
-  let allow;
-
-  a.remove();
-
-  if (vendor === 'youtube-base') {
-    source = `https://www.youtube.com/embed/${id}`;
-    className = 'youtube-player';
-    allow = 'encrypted-media; accelerometer; gyroscope; picture-in-picture';
-  } else if (vendor === 'spotify-base') {
-    source = `https://open.spotify.com/embed/episode/${id}`;
-    className = 'spotify-player';
-    allow = 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture';
-  } else if (vendor === 'wistia-base') {
-    source = `https://fast.wistia.net/embed/iframe/${id}`;
-    className = 'wistia-player';
-    allow = 'autoplay; clipboard-write; encrypted-media; fullscreen;';
-  }
-
-  div.innerHTML = `<iframe src="${source}" 
-        class="${className}"
-        allowfullscreen  
-        allow="${allow}"
-        loading="lazy">
-    </iframe>`;
-}
-
-function decorateEmbed() {
-  const embedObserver = new IntersectionObserver((entries) => {
-    entries.forEach(
-      (entry) => {
-        if (entry.isIntersecting) {
-          embedObserver.unobserve(entry.target);
-          createIframe(entry.target);
-        }
-      },
-    );
-  });
-
-  main.querySelectorAll('.embed').forEach((div) => {
-    embedObserver.observe(div);
-  });
-}
-
 function loadLaunch() {
   window.adobeDataLayer = window.adobeDataLayer || [];
 
@@ -126,7 +76,6 @@ class ScrollIndicator {
 }
 
 decorateTwitterFeed();
-decorateEmbed();
 loadLaunch();
 loadLiveUXRUM();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -182,6 +182,12 @@ function preDecorateEmbed(main) {
     lazyEmbeds.forEach((lazyEmbed) => {
       lazyEmbedObserver.observe(lazyEmbed);
     });
+  } else {
+    lazyEmbeds.forEach((embed) => {
+      const iframe = embed.querySelector('iframe');
+      iframe.src = iframe.dataset.src;
+      iframe.style.display = iframe.style.display === "none" ? "" : "none";
+    });
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -186,7 +186,7 @@ function preDecorateEmbed(main) {
     lazyEmbeds.forEach((embed) => {
       const iframe = embed.querySelector('iframe');
       iframe.src = iframe.dataset.src;
-      iframe.style.display = iframe.style.display === "none" ? "" : "none";
+      iframe.style.display = iframe.style.display === 'none' ? '' : 'none';
     });
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -141,7 +141,7 @@ function createEmbedIFrame(a, vendor) {
         allowfullscreen  
         allow="${allow}"
         style="display: none"
-        loading="lazy">
+        loading="auto">
     </iframe>`;
 
   a.replaceWith(div);


### PR DESCRIPTION
Fix #182

Since we anyway used the `IntersectionObserver` I moved the iframe creation back to `scripts.js.` While this improves the UX and the page feels loading faster it has negative impact on LHS (desktop only). As the video on the homepage is in the initial viewport and the `IntersectionObserver` is triggered immediately.

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/
- After: https://video-loading2--cn-website--netcentric.hlx.page/
