### PR TITLE
#198 nav chevrons are visible when are visible

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -161,6 +161,8 @@ header nav .nav-sections li span.icon.icon-chevron-right, header nav .nav-sectio
   cursor: pointer;
 }
 
+header .nav-sections li[aria-expanded='true'] .nav-drop span.icon-chevron-right,
+header nav[aria-expanded='true'] .nav-sections li span.icon.icon-chevron-right,
 header nav[aria-expanded='true'] .nav-sections li span.icon.icon-chevron-right svg {
   display: initial;
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -153,18 +153,12 @@ header nav .nav-sections span.close-menu-arrow svg {
   transform: rotate(180deg);
 }
 
-header nav .nav-sections li span.icon.icon-chevron-right, header nav .nav-sections li span.icon.icon-chevron-right svg {
-  display: none;
+header nav .nav-sections li span.icon.icon-chevron-right,
+header nav .nav-sections li span.icon.icon-chevron-right svg {
   width: 16px;
   height: 16px;
   fill: white;
   cursor: pointer;
-}
-
-header .nav-sections li[aria-expanded='true'] .nav-drop span.icon-chevron-right,
-header nav[aria-expanded='true'] .nav-sections li span.icon.icon-chevron-right,
-header nav[aria-expanded='true'] .nav-sections li span.icon.icon-chevron-right svg {
-  display: initial;
 }
 
 /* tools */
@@ -406,7 +400,12 @@ header nav .nav-sections ul > li.nav-drop[aria-expanded='true'] > .nav-drop-ul-w
     text-align: left;
     line-height: 1em;
     text-transform: uppercase;
-   }
+  }
+
+  header .nav-sections > ul > .nav-drop > .icon {
+    display: none;
+  }
+
 
   /* Let's talk button */
   header nav .nav-tools > ul > li:last-of-type > a {


### PR DESCRIPTION
in mobile and in desktop portraits, chevrons are visible when the dropdown is visible

Fix #198 

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/
- After: https://198-arrows-in-navigation-are-missing--cn-website--netcentric.hlx.page/
