### PR TITLE
#177: added auto block for forms if only Marketo URL is present

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -1,4 +1,5 @@
 import { loadCSS } from '../../scripts/lib-franklin.js';
+import { isMarketoFormUrl } from '../../scripts/scripts.js';
 
 const loadScript = (url, callback, type) => {
   const head = document.querySelector('head');
@@ -384,7 +385,7 @@ export default async function decorate(block) {
   const form = block.querySelector('a[href]');
   try {
     const target = new URL(form?.href);
-    if (target.hostname === 'engage-lon.marketo.com') {
+    if (isMarketoFormUrl(target)) {
       loadCSS('/blocks/form/form-marketo.css');
       const [, formId] = target.hash.split('#/mktForm/');
       const munchkinId = new URLSearchParams(target.search).get('munchkinId');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -194,6 +194,38 @@ function preDecorateEmbed(main) {
   }
 }
 
+export function isMarketoFormUrl(url) {
+  return url.hostname === 'engage-lon.marketo.com';
+}
+
+function findParent(element, callback) {
+  if (!element.parentElement) {
+    return null;
+  }
+  if (callback(element.parentElement)) {
+    return element.parentElement;
+  }
+  return findParent(element.parentElement, callback);
+}
+
+function preDecorateMarketoForm(main) {
+  [...main.getElementsByTagName('a')].filter((a) => {
+    try {
+      return a.href
+        && isMarketoFormUrl(new URL(a.href))
+        && !findParent(a, (parent) => parent.classList.contains('form'));
+    } catch (e) {
+      console.error('error while parsind form anchors', e);
+      return false;
+    }
+  }).forEach((a) => {
+    const formDiv = document.createElement('div');
+    formDiv.classList.add('form');
+    formDiv.innerHTML = `<div><div>${a.outerHTML}</div></div>`;
+    a.parentElement.replaceWith(formDiv);
+  });
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -237,6 +269,7 @@ export async function decorateMain(main) {
   await fetchPlaceholders();
   await buildAutoBlocks(main);
   decorateSections(main);
+  preDecorateMarketoForm(main);
   decorateBlocks(main);
   preDecorateEmbed(main);
 }


### PR DESCRIPTION
Fix #177 

Test URLs:
- https://177-marketo-auto-form--cn-website--netcentric.hlx.live/drafts/ahaller/ncwhitepaper-content-velocity
