### PR TITLE
#248 Search is hided in DE

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -177,6 +177,10 @@ header nav .nav-sections li span.icon.icon-chevron-right svg {
   background-color: var(--c-dark-plum);
 }
 
+:lang(de) .nav-search {
+  display: none;
+}
+
 header nav[aria-expanded='true'] .nav-search {
   display: initial;
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -226,7 +226,6 @@ export default async function decorate(block) {
       url.search = params;
       window.open(url.href, '_self');
     });
-    if (getLanguagePath() === '/de') navSearch.style.display = 'none';
 
     // mobile language selector
     const langToggleButton = document.createElement('button');

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -196,6 +196,7 @@ export default async function decorate(block) {
       url.search = params;
       window.open(url.href, '_self');
     });
+    if (getLanguagePath() === '/de') navSearch.style.display = 'none';
 
     // mobile language selector
     const langToggleButton = document.createElement('button');


### PR DESCRIPTION
The _/de/nav_ version has been updated using the previous AEM _de.html_ version and all links point to the _/de_ folder. Some links haven't **_/de_** version yet, so that goes to a 404 error (or redirects to the main version in PROD)

These links are broken by now:
- /de/how-we-work/aec-expert-community

Fix #248

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/de
- After: https://248-hide-search-on-german--cn-website--netcentric.hlx.page/de
