### PR TITLE
#246: add index definition for the German site tree

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -105,6 +105,8 @@ indices:
     include:
       - '/de'
       - '/de/**'
+    exclude:
+      - '/de/drafts/**'
     target: /de/query-index-search.json
     properties:
       title:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -101,3 +101,27 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+  searchDe:
+    include:
+      - '/de'
+      - '/de/**'
+    target: /de/query-index-search.json
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      description:
+        select: head > meta[name="description"]
+        value: attribute(el, "content")
+      fulltext:
+        select: main
+        value: textContent(el)
+      robots:
+        select: head > meta[name="robots"]
+        value: attribute(el, 'content')
+      status:
+        select: head > meta[name="site-search"]
+        value: attribute(el, 'content')
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")


### PR DESCRIPTION
Fix #246 

Test URLs:
- https://246-german-index-file--cn-website--netcentric.hlx.page/
