### PR TITLE
#286 add new class to center buttons only

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -309,6 +309,10 @@ button:disabled:hover {
   cursor: unset;
 }
 
+.btn-center p.button-container {
+  text-align: center;
+}
+
 main a.button > .icon-chevron-right,
 main a.button > .icon-chevron-right svg {
   width: 12px;


### PR DESCRIPTION
This feature adds a new command keyword as section metadata style -> btn-center

Fix #286 

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/drafts/jlledo/fan-engagement-platform
- After: https://286-center-button-only-from-text--cn-website--netcentric.hlx.page/drafts/jlledo/fan-engagement-platform
