### PR TITLE
Fix #295: Adds 90s delay to notify ingest API

### DIFF
--- a/.github/workflows/search-trigger.yaml
+++ b/.github/workflows/search-trigger.yaml
@@ -17,6 +17,9 @@ jobs:
     if: (github.event.client_payload.status == 200 || github.event.client_payload.status == 204) && endsWith(github.event.client_payload.path, '.md')
     runs-on: ubuntu-latest
     steps:
+    - name: Sleep for 90 seconds assuming query-index-search.json will be updated before
+      run: sleep 90s
+      shell: bash
     - name: Remove .md extension
       id: removeMd
       uses: frabert/replace-string-action@v2


### PR DESCRIPTION
The search ingest REST API must be notified so it can pull content from query-index-search.yml . However, it takes around 60s for it to be updated. With this change, the pull for content should succeed.