### PR TITLE
#362: LiveUX Origin header

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -16,6 +16,9 @@ function injectScript(src) {
 
     script.src = src;
     script.setAttribute('async', 'true');
+    if (src.startsWith('http')) {
+      script.crossOrigin = 'anonymous';
+    }
     head.append(script);
     window.scriptsLoaded.push(src);
   }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -7,7 +7,7 @@ sampleRUM('cwv');
 // add more delayed functionality here
 const main = document.querySelector('main');
 
-function injectScript(src) {
+function injectScript(src, crossOrigin = '') {
   window.scriptsLoaded = window.scriptsLoaded || [];
 
   if (window.scriptsLoaded.indexOf(src)) {
@@ -16,8 +16,8 @@ function injectScript(src) {
 
     script.src = src;
     script.setAttribute('async', 'true');
-    if (src.startsWith('http')) {
-      script.crossOrigin = 'anonymous';
+    if (['anonymous', 'use-credentials'].includes(crossOrigin)) {
+      script.crossOrigin = crossOrigin;
     }
     head.append(script);
     window.scriptsLoaded.push(src);
@@ -49,7 +49,7 @@ function loadLaunch() {
 
 function loadLiveUXRUM() {
   const src = 'https://liveux.cnwebperformance.biz/collector/collector.min.js?id=webperf-netcentric';
-  injectScript(src);
+  injectScript(src, 'anonymous');
 }
 
 function loadSidekickExtension() {


### PR DESCRIPTION
add crossOrigin flag to LiveUX script to let the browser add the origin header on the request

Fix #362 

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/
- After: https://362-liveux-origin-header--cn-website--netcentric.hlx.page/
