### PR TITLE
373 - change default link to blog overview button

### DIFF
--- a/blocks/related-blogs/related-blogs.js
+++ b/blocks/related-blogs/related-blogs.js
@@ -17,7 +17,7 @@ function buildCTASection(parent, checkBtnLink, count) {
   if (checkBtnLink && count > 1) {
     buttonRow.innerHTML = `<a href="${checkBtnLink}" class="button secondary">${window.placeholders?.default?.blogOverview || 'Blog Overview'}</a>`;
   } else {
-    buttonRow.innerHTML = `<a href="/insights" class="button secondary">${window.placeholders?.default?.blogOverview || 'Blog Overview'}</a>`;
+    buttonRow.innerHTML = `<a href="/insights/blog" class="button secondary">${window.placeholders?.default?.blogOverview || 'Blog Overview'}</a>`;
   }
   addChevronToButtons(buttonRow);
   decorateIcons(buttonRow);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/
- After: https://373-blog-overview-goes-to-wrong--cn-website--netcentric.hlx.page/our-industries/financial-services-insurance
