### PR TITLE
Fix #392-Add a class to center columns text

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -228,4 +228,8 @@
     .columns.border-in-between > div > div:not(:first-of-type) {
         padding-left: 4.1667%;
     }
+
+    .text-center {
+      text-align: center;
+    }
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix ##392

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/
- After: https://392-benefits-icons-bug--cn-website--netcentric.hlx.page/

to fix this issue the class columns-3-cols needs to be added in the column container. I added a text-center class to center the text beneath each icon.





