### PR TITLE
336 metadata content animation

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -319,35 +319,18 @@ export function readBlockConfig(block) {
 /**
  * adds animation on metadata level
  */
-export function addAnimation() {
+export function addAnimation(animationTypeMeta, root) {
   const addClass = (elem, className) => {
     elem.classList.add(className);
   };
 
-  const animationTypeMeta = getMetadata('animated');
+  const elementsToAnimate = root.querySelectorAll('h1, h2, h3, h4, h5, h6, a, img');
 
-  const elementsToAnimate = document.querySelectorAll('h1, h2, h3, h4, h5, h6, a, img');
-
-  const applyAnimation = (entries) => {
+  const applyAnimation = (entries, observer) => {
     entries.forEach((entry) => {
       if (entry.isIntersecting && entry.intersectionRatio >= 0.3) {
-        switch (animationTypeMeta) {
-          case 'up':
-            addClass(entry.target, 'animated-up');
-            break;
-          case 'down':
-            addClass(entry.target, 'animated-down');
-            break;
-          case 'left':
-            addClass(entry.target, 'animated-left');
-            break;
-          case 'right':
-            addClass(entry.target, 'animated-right');
-            break;
-          default:
-            break;
-        }
-        // eslint-disable-next-line no-use-before-define
+        addClass(entry.target, `animated-${animationTypeMeta}`);
+
         observer.unobserve(entry.target); // Stop observing once animation is applied
       }
     });
@@ -405,6 +388,8 @@ export function decorateSections(main) {
         if (key === 'style') {
           const styles = meta.style.split(',').map((style) => toClassName(style.trim()));
           styles.forEach((style) => section.classList.add(style));
+        } else if (key === 'animated') {
+          addAnimation(meta[key], section);
         } else {
           section.dataset[toCamelCase(key)] = meta[key];
         }
@@ -711,7 +696,7 @@ function init() {
     sampleRUM('error', { source: event.filename, target: event.lineno });
   });
 
-  addAnimation();
+  addAnimation(getMetadata('animated'), document);
 }
 
 init();

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -324,7 +324,7 @@ export function addAnimation() {
     elem.classList.add(className);
   };
 
-  const animationTypeMeta = getMetadata('animation');
+  const animationTypeMeta = getMetadata('animated');
 
   const elementsToAnimate = document.querySelectorAll('h1, h2, h3, h4, h5, h6, a, img');
 

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -317,6 +317,66 @@ export function readBlockConfig(block) {
 }
 
 /**
+ * adds animation on metadata level
+ */
+export function addAnimation() {
+  const addClass = (elem, className) => {
+    elem.classList.add(className);
+  };
+
+  const animationTypeMeta = getMetadata('animation');
+
+  const elementsToAnimate = document.querySelectorAll('h1, h2, h3, h4, h5, h6, a, img');
+
+  const applyAnimation = (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting && entry.intersectionRatio >= 0.3) {
+        switch (animationTypeMeta) {
+          case 'up':
+            addClass(entry.target, 'animated-up');
+            break;
+          case 'down':
+            addClass(entry.target, 'animated-down');
+            break;
+          case 'left':
+            addClass(entry.target, 'animated-left');
+            break;
+          case 'right':
+            addClass(entry.target, 'animated-right');
+            break;
+          default:
+            break;
+        }
+        // eslint-disable-next-line no-use-before-define
+        observer.unobserve(entry.target); // Stop observing once animation is applied
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(applyAnimation, { threshold: 0.3 });
+
+  elementsToAnimate.forEach((element) => {
+    observer.observe(element);
+  });
+
+  // Observe the body for changes
+  const bodyObserver = new MutationObserver(() => {
+    elementsToAnimate.forEach((element) => {
+      observer.observe(element);
+    });
+  });
+
+  bodyObserver.observe(document.body, { childList: true, subtree: true });
+
+  // Observe the window for scrolling
+  window.addEventListener('scroll', () => {
+    elementsToAnimate.forEach((element) => {
+      observer.observe(element);
+    });
+  });
+}
+
+/**
  * Decorates all sections in a container element.
  * @param {Element} $main The container element
  */
@@ -650,6 +710,8 @@ function init() {
   window.addEventListener('error', (event) => {
     sampleRUM('error', { source: event.filename, target: event.lineno });
   });
+
+  addAnimation();
 }
 
 init();

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -653,3 +653,99 @@ main .section.text-white {
   white-space: nowrap;
   width: 1px;
 }
+
+/* animations */
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes animated-up {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes animated-down {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes animated-right {
+  0% {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes animated-left {
+  0% {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* animations written on metadata level */
+
+.animated-up {
+  animation: animated-up 0.5s ease-in-out forwards;
+}
+
+.animated-down {
+  animation: animated-down 0.5s ease-in-out forwards;
+}
+
+.animated-right {
+  animation: animated-right 0.5s ease-in-out forwards;
+}
+
+.animated-left {
+  animation: animated-left 0.5s ease-in-out forwards;
+}
+
+/* animations written on section-metadata level */
+
+ .section-animated-up {
+  animation: animated-up 0.5s ease-in-out forwards;
+}
+
+  .section-animated-down {
+  animation: animated-down 0.5s ease-in-out forwards;
+}
+
+ .section-animated-right {
+  animation: animated-right 0.5s ease-in-out forwards;
+}
+
+ .section-animated-left {
+  animation: animated-left 0.5s ease-in-out forwards;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -732,20 +732,7 @@ main .section.text-white {
   animation: animated-left 0.5s ease-in-out forwards;
 }
 
-/* animations written on section-metadata level */
-
- .section-animated-up {
-  animation: animated-up 0.5s ease-in-out forwards;
+.animated-none {
+  animation: none;
 }
 
-  .section-animated-down {
-  animation: animated-down 0.5s ease-in-out forwards;
-}
-
- .section-animated-right {
-  animation: animated-right 0.5s ease-in-out forwards;
-}
-
- .section-animated-left {
-  animation: animated-left 0.5s ease-in-out forwards;
-}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #336

Test URLs:
- Before: https://main--cn-website--netcentric.hlx.page/
- After: https://336-metadata-content-animation--cn-website--netcentric.hlx.page/drafts/vacosta/copy-of-index

To test this add a column with the key "animated" both on metadata and section metadata.
Values can be UP, LEFT, RIGHT, DOWN and NONE

To add animation on a general level:
![image](https://github.com/Netcentric/cn-website/assets/144350525/7cc36287-2b4c-428c-aacb-4f74e1cde756)


To add animation on a section level:
![image](https://github.com/Netcentric/cn-website/assets/144350525/37d9fefc-87d6-491b-b5f1-0135809b0162)

