### PR TITLE
Fix checks for pre-hlx5 domains and change PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--cn-website--netcentric.hlx.page/
-- After: https://<branch>--cn-website--netcentric.hlx.page/
+- Before: https://main--cn-website--netcentric.aem.live/
+- After: https://<branch>--cn-website--netcentric.aem.live/

--- a/plugins/experimentation/src/index.js
+++ b/plugins/experimentation/src/index.js
@@ -679,6 +679,7 @@ export async function loadLazy(document, options, context) {
     ...(options || {}),
   };
   if (window.location.hostname.endsWith('hlx.page')
+    || window.location.hostname.endsWith('aem.page')
     || window.location.hostname === ('localhost')
     || (typeof options.isProd === 'function' && !options.isProd())
     || (options.prodHost && options.prodHost !== window.location.origin)) {


### PR DESCRIPTION
Test URLs:
- Before: https://main--cn-website--netcentric.aem.live/
- After: https://fix-hlx5-domains--cn-website--netcentric.aem.live/
