### PR TITLE
fix: header search bar style

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -243,18 +243,21 @@ header nav[aria-expanded='true'] .nav-search {
 .search-form .search-input {
   border-top-left-radius: 0.3em;
   border-bottom-left-radius: 0.3em;
+  border-inline-end: none;
   flex-grow: 2;
 }
 
 .search-form :where(input, button) {
   border-width: thin;
   border-color: var(--c-dark-plum);
+  border-style: solid
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
 .nav-search svg {
   height: 1em;
   width: 1em;
+  vertical-align: top;
 }
 
 /* tools */


### PR DESCRIPTION
Left is before, right is after

![Kapture 2025-05-14 at 11 59 53](https://github.com/user-attachments/assets/2dde6a59-c6bc-4f98-b429-081afa8699b1)


Test URLs:
- Before: https://main--cn-website--netcentric.aem.live/
- After: https://fix-header-searchbar-style--cn-website--netcentric.aem.live/
