### PR TITLE
422 – Footer section to monochrome color scheme

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -1,7 +1,7 @@
 footer {
-  background-color: var(--c-dark-mid-plum);
+  background-color: var(--c-dark-plum);
   font-size: var(--body-font-size-m);
-  color: white;
+  color: var(--c-white);
 }
 
 .footer {
@@ -15,7 +15,7 @@ footer {
 }
 
 .footer a {
-  color: white;
+  color: var(--c-white);
   text-decoration: none;
 }
 
@@ -81,7 +81,7 @@ footer .icon svg {
   font-size: 46px;
   height: 1em;
   width: 1em;
-  fill: currentcolor;
+  fill: var(--c-white);
   display: inline-block;
 }
 

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -19,6 +19,10 @@ footer {
   text-decoration: none;
 }
 
+.footer a:hover {
+  text-decoration: underline;
+}
+
 /* main footer section that contains the different subsections */
 footer > div > div {
   display: flex;


### PR DESCRIPTION
Feature #422

Changes should include changing the background color to dark plum, text and social media icon colors to white. Hover states for the links should also now be underlined as per requirements.

Test URLs:
- Before: https://main--cn-website--netcentric.aem.live/
- After: https://422-footer-monochrome--cn-website--netcentric.aem.live/